### PR TITLE
Change 'In the code above above' to 'In the code above'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ ReactDOM.render(
 );
 ```
 
-**Step 1**: In the code above above, there are two components that we are
+**Step 1**: In the code above, there are two components that we are
 importing from **React Router**. We use them in turn.
 
 **Step 2**: The `BrowserRouter` component is the base for our application's


### PR DESCRIPTION
Fixed a typo inside the README.md, on line 107. 